### PR TITLE
Replace NoDogMoms.com references with NotADogMom.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,21 +3,21 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NoDogMoms.com | Public Service Announcement on CMDD</title>
+    <title>NotADogMom.com | Public Service Announcement on CMDD</title>
     <meta name="description" content="Official PSA from the Institute for Maternal Canine Studies on Canine Maternal Delusion Disorder (CMDD). Only dogs can be the moms of dogs.">
     <meta name="author" content="Institute for Maternal Canine Studies">
     <meta name="keywords" content="CMDD, dog mom, pet guardian, canine maternal delusion disorder, PSA">
-    <meta property="og:title" content="NoDogMoms.com | CMDD Public Service Announcement">
+    <meta property="og:title" content="NotADogMom.com | CMDD Public Service Announcement">
     <meta property="og:description" content="Canine Maternal Delusion Disorder affects thousands. Learn the facts from the Institute for Maternal Canine Studies.">
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="NoDogMoms.com">
+    <meta property="og:site_name" content="NotADogMom.com">
     <meta property="og:image" content="/hero-dog.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@IMCS_Official">
-    <meta name="twitter:title" content="NoDogMoms.com | CMDD Public Service Announcement">
+    <meta name="twitter:title" content="NotADogMom.com | CMDD Public Service Announcement">
     <meta name="twitter:description" content="Only dogs can be the moms of dogs. Learn about CMDD from the Institute for Maternal Canine Studies.">
     <meta name="twitter:image" content="/hero-dog.png">
-    <link rel="canonical" href="https://nodogmoms.com/">
+    <link rel="canonical" href="https://notadogmom.com/">
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -43,7 +43,7 @@ const Navigation = () => {
               />
               <div className="flex flex-col">
                 <span className="text-lg font-bold text-government-navy">
-                  NoDogMoms.com
+                  NotADogMom.com
                 </span>
                 <span className="text-xs text-government-gray uppercase tracking-wider">
                   Official IMCS Resource

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 @tailwind components;
 @tailwind utilities;
 
-/* NoDogMoms.com Design System - Governmental/Clinical Aesthetic */
+/* NotADogMom.com Design System - Governmental/Clinical Aesthetic */
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- replace NoDogMoms.com with NotADogMom.com in site metadata and navigation
- update canonical link to the new domain
- adjust design system comment to use NotADogMom.com

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 3 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bac69af0c4832ca176a4cec6fc2636